### PR TITLE
Fix: Make release github action conditionally run plan

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,10 +76,12 @@ jobs:
       # but also really annoying to build CI around when it needs secrets to work right.)
       - id: plan
         run: |
-          dist host --allow-dirty --steps=create ${{ format('--tag=send_with_us-{0}', github.ref_name) }} --output-format=json > plan-dist-manifest.json
-          echo "dist ran successfully"
-          cat plan-dist-manifest.json
-          echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          if [ -n "${{ !github.event.pull_request && github.ref_name || '' }}" ]; then
+            dist host --allow-dirty --steps=create ${{ format('--tag=send_with_us-{0}', github.ref_name) }} --output-format=json > plan-dist-manifest.json
+            echo "dist ran successfully"
+            cat plan-dist-manifest.json
+            echo "manifest=$(jq -c "." plan-dist-manifest.json)" >> "$GITHUB_OUTPUT"
+          fi
       - name: "Upload dist-manifest.json"
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -107,44 +107,47 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 ### Working with Templates
 
 ```rust , ignore
-# use send_with_us::{Api, ApiClient, types::{TemplateOptions}};
-# use serde_json::Value;
-# #[tokio::main]
-# async fn main() -> Result<(), Box<dyn std::error::Error>> {
-let api = Api::with_api_key("YOUR_API_KEY");
+use send_with_us::{Api, ApiClient, types::{TemplateOptions}};
+use serde_json::Value;
 
-let template = TemplateOptions {
-  name: "Welcome Email".to_string(),
-  subject: "Welcome to Our Service".to_string(),
-  html: "<html><body>Welcome, {{name}}!</body></html>".to_string(),
-  text: "Welcome, {{name}}!".to_string(),
-  preheader: Some("Welcome to our service".to_string()),
-  amp_html: None,
-};
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+  let api = Api::with_api_key("YOUR_API_KEY");
+  
+  let template = TemplateOptions {
+    name: "Welcome Email".to_string(),
+    subject: "Welcome to Our Service".to_string(),
+    html: "<html><body>Welcome, {{name}}!</body></html>".to_string(),
+    text: "Welcome, {{name}}!".to_string(),
+    preheader: Some("Welcome to our service".to_string()),
+    amp_html: None,
+  };
 
-let result = api.create_template(template).await?;
-# Ok(())
-# }
+  let result = api.create_template(template).await?;
+
+  Ok(())
+}
 ```
 
 ### Error Handling
 
 ```rust , ignore
-# use send_with_us::{Api, ApiClient, Error, types::{EmailOptions, Recipient}};
-# #[tokio::main]
-# async fn main() {
-let api = Api::with_api_key("YOUR_API_KEY");
-let recipient = Recipient::new("test@example.com");
-let options = EmailOptions::new("", recipient); // Empty template ID
+use send_with_us::{Api, ApiClient, Error, types::{EmailOptions, Recipient}};
+#[tokio::main]
 
-match api.send_email(options).await {
-  Ok(response) => println!("Email sent: {:?}", response),
-  Err(Error::MissingTemplateId) => eprintln!("Error: Template ID is required"),
-  Err(Error::InvalidCredentials) => eprintln!("Error: Invalid API key"),
-  Err(Error::ConnectionFailed) => eprintln!("Error: Could not connect to SendWithUs API"),
-  Err(err) => eprintln!("Error: {}", err),
+async fn main() {
+  let api = Api::with_api_key("YOUR_API_KEY");
+  let recipient = Recipient::new("test@example.com");
+  let options = EmailOptions::new("", recipient); // Empty template ID
+
+  match api.send_email(options).await {
+    Ok(response) => println!("Email sent: {:?}", response),
+    Err(Error::MissingTemplateId) => eprintln!("Error: Template ID is required"),
+    Err(Error::InvalidCredentials) => eprintln!("Error: Invalid API key"),
+    Err(Error::ConnectionFailed) => eprintln!("Error: Could not connect to SendWithUs API"),
+    Err(err) => eprintln!("Error: {}", err),
+  }
 }
-# }
 ```
 
 ## API Documentation


### PR DESCRIPTION
In order to ensure we only run dist plan on events that are essentially not pull requests (tags), this commit adds some conditional shell script logic to the plan step in release.yml that ensures the github event that triggered release is not a pull request.